### PR TITLE
fix issue 22 with type change

### DIFF
--- a/create-static-map/create-static-map.go
+++ b/create-static-map/create-static-map.go
@@ -72,7 +72,7 @@ func handleBboxOption(ctx *sm.Context, parameter string) {
 		log.Fatal(err)
 	}
 
-    var bbox s2.Rect
+	var bbox *s2.Rect
 	bbox, err = sm.CreateBBox(nwlat, nwlng, selat, selng)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
prevents the following error when compiling:
/usr/local/opt/go/bin/src/github.com/flopp/go-staticmaps/create-static-map/create-static-map.go:76:
cannot assign *s2.Rect to bbox (type s2.Rect) in multiple assignment
/usr/local/opt/go/bin/src/github.com/flopp/go-staticmaps/create-static-map/create-static-map.go:81:
invalid indirect of bbox (type s2.Rect)