### PR TITLE
Don't draw attribution if empty

### DIFF
--- a/context.go
+++ b/context.go
@@ -305,6 +305,9 @@ func (m *Context) Render() (image.Image, error) {
 		draw.Src)
 
 	// draw attribution
+	if m.tileProvider.Attribution == "" {
+		return croppedImg, nil
+	}
 	_, textHeight := gc.MeasureString(m.tileProvider.Attribution)
 	boxHeight := textHeight + 4.0
 	gc = gg.NewContextForRGBA(croppedImg)


### PR DESCRIPTION
We use our own custom tile provider and we don't need to display attribution. This PR introduces the behavior to draw attribution only if the tile provider has non-empty attribution property.