### PR TITLE
Make TileProvider an interface (or: maybe this is just an FYI rather than a PR...)

### DIFF
--- a/tile_fetcher.go
+++ b/tile_fetcher.go
@@ -12,9 +12,9 @@ import (
 	_ "image/jpeg" // to be able to decode jpegs
 	_ "image/png"  // to be able to decode pngs
 	"io"
-	"io/ioutil"
+	//"io/ioutil"
 	"log"
-	"net/http"
+	//"net/http"
 	"os"
 	"path/filepath"
 

--- a/tile_provider.go
+++ b/tile_provider.go
@@ -7,10 +7,11 @@ package sm
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 )
 
-func fetchURL(url) ([]byte, error) {
+func fetchURL(url string) ([]byte, error) {
 
 	req, err := http.NewRequest("GET", url, nil)
 
@@ -44,7 +45,7 @@ type TileProvider interface {
 	URLPattern() string
 	TileURL(int, int, int) string
 	Shards() []string
-	FetchTile() ([]byte, error)
+	FetchTile(int, int, int) ([]byte, error)
 }
 
 type DefaultTileProvider struct {
@@ -64,7 +65,7 @@ func (t *DefaultTileProvider) Attribution() string {
 	return t.attribution
 }
 
-func (t *DefaultTileProvider) TileSize() string {
+func (t *DefaultTileProvider) TileSize() int {
 	return t.tileSize
 }
 
@@ -236,7 +237,7 @@ func GetTileProviders() map[string]TileProvider {
 	}
 
 	for _, tp := range list {
-		m[tp.Name] = tp
+		m[tp.Name()] = tp
 	}
 
 	return m


### PR DESCRIPTION
I recently had to fork `go-staticmaps` and change the default `TileProvider` struct in to an interface (and update things accordingly) in order to it with so-called "rasterzen" tiles:

https://github.com/whosonfirst/go-rasterzen

These are ([Nextzen](https://www.nextzen.org/)) vector tiles by default that get rendered in SVG/PNG tiles in code so the default model of fetching a URL (in `tile_fetcher.go`) and decoding the bytes doesn't work for rasterzen tiles. It's also meant moving the actual HTTP request in the tile provider which is maybe messier than you'd like:

https://github.com/whosonfirst/go-whosonfirst-staticmaps/blob/rasterzen/provider/rasterzen.go

Anyway, I just wanted to mention that there was a need to do this. If there's a different/better way to accomplish the same thing then I am happy enough to change my code. 

The end result is this:

https://github.com/whosonfirst/go-whosonfirst-staticmaps/tree/rasterzen#wof-staticmap

Also, thanks for writing `go-staticmaps` in the first place :-)