### PR TITLE
Use one cache-dir per provider

### DIFF
--- a/context.go
+++ b/context.go
@@ -58,7 +58,7 @@ func NewContext() *Context {
 	t.background = nil
 	t.userAgent = ""
 	t.tileProvider = NewTileProviderOpenStreetMaps()
-	t.cache = NewTileCacheFromUserCache(t.tileProvider.Name, 0777)
+	t.cache = NewTileCacheFromUserCache(0777)
 	return t
 }
 

--- a/tile_cache.go
+++ b/tile_cache.go
@@ -1,7 +1,6 @@
 package sm
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/Wessie/appdirs"
@@ -40,10 +39,10 @@ func NewTileCache(rootPath string, perm os.FileMode) *TileCacheStaticPath {
 }
 
 // NewTileCacheFromUserCache stores cache files in a user-specific cache directory.
-func NewTileCacheFromUserCache(name string, perm os.FileMode) *TileCacheStaticPath {
+func NewTileCacheFromUserCache(perm os.FileMode) *TileCacheStaticPath {
 	app := appdirs.New("go-staticmaps", "flopp.net", "0.1")
 	return &TileCacheStaticPath{
-		path: fmt.Sprintf("%s/%s", app.UserCache(), name),
+		path: app.UserCache(),
 		perm: perm,
 	}
 }

--- a/tile_fetcher.go
+++ b/tile_fetcher.go
@@ -16,7 +16,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strconv"
 )
 
 // TileFetcher downloads map tile images from a TileProvider
@@ -49,14 +51,20 @@ func (t *TileFetcher) url(zoom, x, y int) string {
 	return t.tileProvider.getURL(shard, zoom, x, y)
 }
 
-func cacheFileName(cache TileCache, zoom int, x, y int) string {
-	return fmt.Sprintf("%s/%d/%d/%d", cache.Path(), zoom, x, y)
+func cacheFileName(cache TileCache, providerName string, zoom, x, y int) string {
+	return path.Join(
+		cache.Path(),
+		providerName,
+		strconv.Itoa(zoom),
+		strconv.Itoa(x),
+		strconv.Itoa(y),
+	)
 }
 
 // Fetch download (or retrieves from the cache) a tile image for the specified zoom level and tile coordinates
 func (t *TileFetcher) Fetch(zoom, x, y int) (image.Image, error) {
 	if t.cache != nil {
-		fileName := cacheFileName(t.cache, zoom, x, y)
+		fileName := cacheFileName(t.cache, t.tileProvider.Name, zoom, x, y)
 		cachedImg, err := t.loadCache(fileName)
 		if err == nil {
 			return cachedImg, nil
@@ -75,7 +83,7 @@ func (t *TileFetcher) Fetch(zoom, x, y int) (image.Image, error) {
 	}
 
 	if t.cache != nil {
-		fileName := cacheFileName(t.cache, zoom, x, y)
+		fileName := cacheFileName(t.cache, t.tileProvider.Name, zoom, x, y)
 		if err := t.storeCache(fileName, data); err != nil {
 			log.Printf("Failed to store map tile as '%s': %s", fileName, err)
 		}


### PR DESCRIPTION
in order to have overlays being cached in their own directory

refs #38