### PR TITLE
Allow to ignore 404 errors for overlays

### DIFF
--- a/context.go
+++ b/context.go
@@ -496,13 +496,17 @@ func (m *Context) renderLayer(gc *gg.Context, zoom int, trans *transformer, tile
 			y := trans.tOriginY + yy
 			if y < 0 || y >= tiles {
 				log.Printf("Skipping out of bounds tile %d/%d", x, y)
+				continue
+			}
+
+			if tileImg, err := t.Fetch(zoom, x, y); err == nil {
+				gc.DrawImage(tileImg, xx*tileSize, yy*tileSize)
+			} else if err == errTileNotFound && provider.IgnoreNotFound {
+				log.Printf("Error downloading tile file: %s (Ignored)", err)
+				continue
 			} else {
-				if tileImg, err := t.Fetch(zoom, x, y); err == nil {
-					gc.DrawImage(tileImg, xx*tileSize, yy*tileSize)
-				} else {
-					log.Printf("Error downloading tile file: %s", err)
-					return err
-				}
+				log.Printf("Error downloading tile file: %s", err)
+				return err
 			}
 		}
 	}

--- a/tile_fetcher.go
+++ b/tile_fetcher.go
@@ -7,6 +7,7 @@ package sm
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"image"
 	_ "image/jpeg" // to be able to decode jpegs
@@ -18,6 +19,8 @@ import (
 	"os"
 	"path/filepath"
 )
+
+var errTileNotFound = errors.New("Error 404: Tile not found")
 
 // TileFetcher downloads map tile images from a TileProvider
 type TileFetcher struct {
@@ -93,7 +96,14 @@ func (t *TileFetcher) download(url string) ([]byte, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode != 200 {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Great! Nothing to do.
+
+	case http.StatusNotFound:
+		return nil, errTileNotFound
+
+	default:
 		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
 	}
 

--- a/tile_provider.go
+++ b/tile_provider.go
@@ -9,11 +9,12 @@ import "fmt"
 
 // TileProvider encapsulates all infos about a map tile provider service (name, url scheme, attribution, etc.)
 type TileProvider struct {
-	Name        string
-	Attribution string
-	TileSize    int
-	URLPattern  string // "%[1]s" => shard, "%[2]d" => zoom, "%[3]d" => x, "%[4]d" => y
-	Shards      []string
+	Name           string
+	Attribution    string
+	IgnoreNotFound bool
+	TileSize       int
+	URLPattern     string // "%[1]s" => shard, "%[2]d" => zoom, "%[3]d" => x, "%[4]d" => y
+	Shards         []string
 }
 
 func (t *TileProvider) getURL(shard string, zoom, x, y int) string {


### PR DESCRIPTION
As some providers like OpenFireMap do not supply empty tiles (in that particular case tiles without hydrants) they will throw HTTP404. To use them the 404s need to be ignored in overlays.

refs #38