### PR TITLE
Added tile to GetTileProviders map

### DIFF
--- a/tile_provider.go
+++ b/tile_provider.go
@@ -161,6 +161,7 @@ func GetTileProviders() map[string]*TileProvider {
 		NewTileProviderCartoLight(),
 		NewTileProviderCartoDark(),
 		NewTileProviderArcgisWorldImagery(),
+		NewTileProviderWikimedia(),
 	}
 
 	for _, tp := range list {


### PR DESCRIPTION
`NewTileProviderWikimedia()` was missing in the available TileProvider list. That missing entry triggers a `panic: runtime error: invalid memory address or nil pointer dereference` when invoking `sm.GetTileProviders()["wikimedia"]`