### PR TITLE
Remove duplicate tile provider entries. Closes flopp/go-staticmaps#56

### DIFF
--- a/tile_provider.go
+++ b/tile_provider.go
@@ -148,8 +148,6 @@ func GetTileProviders() map[string]*TileProvider {
 	m := make(map[string]*TileProvider)
 
 	list := []*TileProvider{
-		NewTileProviderOpenStreetMaps(),
-		NewTileProviderOpenCycleMap(),
 		NewTileProviderThunderforestLandscape(),
 		NewTileProviderThunderforestOutdoors(),
 		NewTileProviderThunderforestTransport(),


### PR DESCRIPTION
Remove duplicate entries from the list of tile providers in `GetTileProviders`.

I can confirm this compiles with the following Go version:

```
❯ go version
go version go1.17.1 darwin/amd64
```

To test, I used the command line utility to recreate the examples shown in README.md. I can confirm example images are generated. There are visual differences with the examples currently shown but these appear to be down to changes in Provider imagery and unrelated to this change.

Let me know if I can do anything else to test this.